### PR TITLE
docs: Adding Contributors file and filling out package.json

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,15 @@
+# Contributors
+
+These people have contributed commits to this project. Other developers have also worked on this project and contributed in other ways, such as design, product management, or tech writing. If you think someone should be here who isn't, please add them!
+
+This list was automatically seeded by running [`git authors`](https://github.com/tj/git-extras/blob/master/Commands.md#git-authors).
+
+- entrpyc
+- Vladislav Ivanov
+- wideyedwonderer
+- Asen Angelov
+- Richard Littauer
+- Wideyedwonderer
+- Toby Clemson
+- HristiyanG
+- thecryptofruit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,32 @@
 {
   "name": "boson-protocol",
+  "description": "An example front-end application for Boson Protocol",
+  "keywords": [
+    "boson",
+    "boson protocol",
+    "reference",
+    "frontend",
+    "front-end"
+  ],
+  "homepage": "https://github.com/bosonprotocol/reference-frontend",
+  "bugs": "https://github.com/bosonprotocol/reference-frontend/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bosonprotocol/reference-frontend.git"
+  },
+  "contributors": [
+    "entrpyc",
+    "Vladislav Ivanov",
+    "wideyedwonderer",
+    "Asen Angelov",
+    "Richard Littauer <richard@burntfen.com> (https://burntfen.com)",
+    "Wideyedwonderer",
+    "Toby Clemson",
+    "HristiyanG",
+    "thecryptofruit"
+  ],
   "version": "0.1.0",
+  "license": "LGPL-3.0-only",
   "private": true,
   "dependencies": {
     "@ethersproject/abi": "^5.0.9",


### PR DESCRIPTION
This should show a bit more who is using this repo and who has contributed to it, as well as making the package.json more usable in the long run.