### PR TITLE
New Offer Form: Seller deposit validation fix

### DIFF
--- a/src/__tests__/unit/helpers/NewOfferFormValidator.test.js
+++ b/src/__tests__/unit/helpers/NewOfferFormValidator.test.js
@@ -277,7 +277,7 @@ describe("NewOfferFormValidator - Seller deposit validation", () => {
             [NAME.PRICE]: 1,
             [NAME.PRICE_C]: "ETH",
             [NAME.SELLER_DEPOSIT]: 1,
-            [NAME.SELLER_DEPOSIT_C]: "ETH"
+            [NAME.DEPOSITS_C]: "ETH"
         };
 
         const existingErrors = [];
@@ -304,7 +304,7 @@ describe("NewOfferFormValidator - Seller deposit validation", () => {
             [NAME.PRICE]: 1,
             [NAME.PRICE_C]: "ETH",
             [NAME.SELLER_DEPOSIT]: -0.1, // Todo check why 0 doesn't fail; must be below 0
-            [NAME.SELLER_DEPOSIT_C]: "ETH"
+            [NAME.DEPOSITS_C]: "ETH"
         };
 
         const existingErrors = [];

--- a/src/helpers/NewOfferFormValidator.js
+++ b/src/helpers/NewOfferFormValidator.js
@@ -149,17 +149,17 @@ const priceValidation = (errorMessages, getData, priceSettings, currentQuantityV
 const sellerDepositValidation = (errorMessages, getData, priceSettings, currentQuantityValue) => {
   let sellerDepositErrorMessage = null;
   const currentSellerDepositValue = getData(NAME.SELLER_DEPOSIT);
+  const currentSellerDepositCurrency = getData(NAME.DEPOSITS_C);
 
-  if (getData(NAME.SELLER_DEPOSIT_C) && currentSellerDepositValue) {
-    const sellerCurrency = getData(NAME.SELLER_DEPOSIT_C);
+  if (currentSellerDepositCurrency && currentSellerDepositValue) {
 
     if (currentSellerDepositValue <= 0) {
       sellerDepositErrorMessage = ValidationConfig.minSellerDepositError;
     }
 
-    if (currentQuantityValue && priceSettings[sellerCurrency].max) {
-      if (currentSellerDepositValue.mul(currentQuantityValue).gt(priceSettings[sellerCurrency].max)) {
-        sellerDepositErrorMessage = `The maximum value is ${toFixed(+ethers.utils.formatEther(priceSettings[sellerCurrency].max.div(currentQuantityValue)), 2)}`;
+    if (currentQuantityValue && priceSettings[currentSellerDepositCurrency].max) {
+      if (currentSellerDepositValue.mul(currentQuantityValue).gt(priceSettings[currentSellerDepositCurrency].max)) {
+        sellerDepositErrorMessage = `The maximum value is ${toFixed(+ethers.utils.formatEther(priceSettings[currentSellerDepositCurrency].max.div(currentQuantityValue)), 2)}`;
       }
     }
 


### PR DESCRIPTION
A change to the NAME map in `src/helpers/Dictionary.js` caused this regression.
@Wideyedwonderer please check `src/helpers/NewOfferFormValidator.js` when making any changes to this map in future.
The relevant tests will fail if this reoccurs (as expected), but only if the change is actually made in all the correct places (i.e. also `src/helpers/NewOfferFormValidator.js`).