### PR TITLE
Don't show suppliers their own voucher sets

### DIFF
--- a/src/contexts/Global.js
+++ b/src/contexts/Global.js
@@ -15,6 +15,7 @@ export const GlobalInitialState = {
   fetchVoucherSets: 1,
   account: null,
   checkDataUpdate: 1,
+  checkAccountUpdate: 1
 };
 
 export const Action = {
@@ -82,7 +83,8 @@ export const GlobalReducer = (state, action) => {
     },
     [DIC.UPDATE_ACCOUNT]: () => {
       return {
-        account: action.payload
+        account: action.payload,
+        checkAccountUpdate: state.checkAccountUpdate * -1
       }
     },
     [DIC.FETCH_VOUCHER_SETS]: () => {

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -58,7 +58,7 @@ function Home() {
         } else {
             setProductBlocks([])
         }
-    }, [voucherSets])
+    }, [voucherSets, globalContext.state.checkAccountUpdate])
 
     const completeOnboarding = () => {
         localStorage.setItem('onboarding-completed', '1')


### PR DESCRIPTION
Related to: https://app.asana.com/0/1199560399769920/1200076353240477

We already filter the voucher sets when loading the screen (on expiry date). This functionality has been extended to also filter out voucher sets where the owner is the same as the currently connected wallet.