### PR TITLE
Redirect to voucher sets list on new voucher set creation

### DIFF
--- a/src/components/offerFlow/SubmitForm.js
+++ b/src/components/offerFlow/SubmitForm.js
@@ -111,6 +111,8 @@ export default function SubmitForm() {
 
             prepareVoucherFormData(correlationId, dataArr, paymentType);
 
+            await createVoucherSet(formData, authData.authToken);
+
             globalContext.dispatch(Action.fetchVoucherSets());
 
             setLoading(0);


### PR DESCRIPTION
Related to: https://app.asana.com/0/1199560399769920/1200116080004635

On creating a new voucher set, the user should be redirected to the list of voucher sets instead of the newly created voucher set's details page.