### PR TITLE
[FE-Refactor]: Fix modal close icon not found - bad link

### DIFF
--- a/src/shared-components/modals/context-modal/ContextModal.js
+++ b/src/shared-components/modals/context-modal/ContextModal.js
@@ -30,7 +30,7 @@ const ContextModal = () => {
                 <div className="contextModalFooter">
                   <div className="closeContext" onClick={hideModal}>
                     <img
-                      src="images/icons/close-context-modal.png"
+                      src="/images/icons/close-context-modal.png"
                       alt="Close"
                     />
                   </div>


### PR DESCRIPTION
Close icon for context-modal was not found due to an incorrect link.