### PR TITLE
Fix: Check if voucher-sets collection has been fetched from be after Redeem

### DIFF
--- a/src/views/voucher-and-set-details/VoucherAndSetDetails.js
+++ b/src/views/voucher-and-set-details/VoucherAndSetDetails.js
@@ -161,7 +161,7 @@ function VoucherAndSetDetails(props) {
   const [transactionProccessing, setTransactionProccessing] = useState(1);
 
   const voucherSets = globalContext.state.allVoucherSets;
-  const voucherSetDetails = voucherSets.find((set) => set.id === voucherId);
+  const voucherSetDetails = voucherSets?.find((set) => set.id === voucherId);
 
   const getProp = (prop) =>
     voucherSetDetails


### PR DESCRIPTION
Dirty fix, for redirecting after redeem action. 
Turns out that we try to fetch the voucher-sets collection again, but there should not be any reason why, since this particular voucher we are redeeming from is on the list. This should be prevented. Will raise a separate issue for that