### PR TITLE
unset loader when data is fetched

### DIFF
--- a/src/contexts/Global.js
+++ b/src/contexts/Global.js
@@ -10,7 +10,7 @@ export const GlobalContext = createContext();
 export const GlobalInitialState = {
   qrReaderActivated: 0,
   onboardingCompleted: localStorage["onboarding-completed"],
-  allVouchers: [],
+  allVouchers: undefined,
   allVoucherSets: undefined,
   fetchVoucherSets: 1,
   account: null,

--- a/src/helpers/ActivityHelper.js
+++ b/src/helpers/ActivityHelper.js
@@ -19,7 +19,7 @@ export const sortBlocks = (blocksArray, voucherType) => {
   };
 
   if (voucherType === VOUCHER_TYPE.voucherSet) {
-    blocksArray.forEach((voucherSet) => {
+    blocksArray?.forEach((voucherSet) => {
       let quantity = voucherSet.qty > 0;
       let activeVouchers = voucherSet.hasActiveVouchers;
       let expired =

--- a/src/helpers/parsers/VoucherAndSetParsers.js
+++ b/src/helpers/parsers/VoucherAndSetParsers.js
@@ -142,7 +142,7 @@ export async function getAccountVouchers(account, modalContext) {
     allAccountVouchers.voucherData &&
     prepareVoucherData(allAccountVouchers.voucherData);
 
-  return vouchersParsed ? vouchersParsed : undefined;
+  return vouchersParsed ? vouchersParsed : [];
 }
 
 export async function getParsedAccountVoucherSets(account) {
@@ -155,7 +155,7 @@ export async function getParsedAccountVoucherSets(account) {
 
   const parsedData = prepareAccountVoucherSetData(accountVoucherSets);
 
-  return parsedData ? parsedData : undefined;
+  return parsedData ? parsedData : [];
 }
 
 export async function getParsedVouchersFromSupply(voucherSetId, account) {

--- a/src/views/activity/Activity.js
+++ b/src/views/activity/Activity.js
@@ -37,7 +37,7 @@ import { WalletConnect } from "../../shared-components/wallet-connect/WalletConn
 import { formatDate } from "../../utils/FormatUtils";
 
 export function ActivityAccountVouchers({ title, voucherSetId, block }) {
-  const [accountVouchers, setAccountVouchers] = useState([]);
+  const [accountVouchers, setAccountVouchers] = useState(undefined);
   const { account } = useWeb3React();
   const modalContext = useContext(ModalContext);
   const [loading, setLoading] = useState(0);
@@ -101,7 +101,7 @@ export function ActivityVoucherSetView() {
 }
 
 export function ActivityVoucherSets() {
-  const [voucherBlocks, setVoucherBlocks] = useState([]);
+  const [voucherBlocks, setVoucherBlocks] = useState(undefined);
   const { account } = useWeb3React();
 
   useEffect(() => {
@@ -130,7 +130,7 @@ function ActivityView(props) {
   } = props;
   const globalContext = useContext(GlobalContext);
 
-  const [resultVouchers, setResultVouchers] = useState([]);
+  const [resultVouchers, setResultVouchers] = useState(undefined);
   const [activeVouchers, setActiveVouchers] = useState([]);
   const [inactiveVouchers, setInactiveVouchers] = useState([]);
   const [pageLoading, setPageLoading] = useState(0);
@@ -225,14 +225,13 @@ function ActivityView(props) {
           getLastAction(a) > getLastAction(b) ? -1 : 1
         )
       );
-
-      if (account && isAuthenticated) {
+      if (account && isAuthenticated && Array.isArray(voucherBlocks)) {
         setPageLoading(0);
       }
     };
 
     sortVouchersToActiveAndInactive();
-  }, [resultVouchers]);
+  }, [resultVouchers, voucherBlocks]);
 
   const activityMessageType = {
     [VOUCHER_TYPE.accountVoucher]: {


### PR DESCRIPTION
Resolves displaying vouchers on Purchased / Offered tabs as being loaded forever. After we fetch the result from the backend, there will always be a final state - either no vouchers are displayed with informational message, or the vouchers themselves