### PR TITLE
Home: Categories - Selected category had ellipsis overflow

### DIFF
--- a/src/views/home/components/category-menu/CategoryMenu.scss
+++ b/src/views/home/components/category-menu/CategoryMenu.scss
@@ -17,10 +17,8 @@
     font-family: $font-third;
     font-weight: 600;
     font-size: 28px;
-    max-width: 50%;
+    max-width: 100%;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     flex-shrink: 0;
     opacity: 0;
     transition: 0.45s ease-in-out;


### PR DESCRIPTION
Related to: https://app.asana.com/0/1199560399769920/1200198304460813

Prior to this change, the selected category (on home page) was showing an ellipsis overflow (e.g. "Automobile" -> "Auto..."). This has been changed to show the full category name.