### PR TITLE
Fix seller deposit currency selection defining buyer currency too

### DIFF
--- a/src/views/new-offer/components/new-offer-price/NewOfferPrice.js
+++ b/src/views/new-offer/components/new-offer-price/NewOfferPrice.js
@@ -227,7 +227,7 @@ function NewOfferPrice({
             data-error={buyerDepositErrorMessage ? "" : null}
           >
             <div className="currency-icon">
-              <span className={"icons " + priceCurrency}>
+              <span className={"icons " + depositsCurrency}>
                 <div className={CURRENCY.ETH}></div>
                 <div className={CURRENCY.BSN}></div>
               </span>


### PR DESCRIPTION
Selecting the Seller's deposit currency should also set the Buyer's deposit currency (and therefore the Buyer's deposit currency logo and max value tooltip).