### PR TITLE
max length now 60

### DIFF
--- a/src/helpers/configs/NewOfferFormValidatorConfig.js
+++ b/src/helpers/configs/NewOfferFormValidatorConfig.js
@@ -73,7 +73,7 @@ export const expiryDateBeforeStartDateError =
 // ADDRESS LINE CONFIG
 export const addressLineSettings = {
   min: 4,
-  max: 20,
+  max: 60,
 };
 
 export const minAddressLengthError = minLengthError(


### PR DESCRIPTION
Address length was too short - 20 symbols. It is now bumped to 60.