### PR TITLE
Remove isSmartWallet check on authentication

### DIFF
--- a/src/hooks/authenticate.js
+++ b/src/hooks/authenticate.js
@@ -40,7 +40,6 @@ export const authenticateUser = async (
     message,
   });
 
-  const isSmartWalletAccount = isSmartWallet(library);
   const signatureLike = await library.send("eth_signTypedData_v4", [
     account,
     data,
@@ -48,7 +47,7 @@ export const authenticateUser = async (
   const signature = await splitSignature(signatureLike);
   const jwt = await verifySignature(
     signerAddress,
-    isSmartWalletAccount,
+    undefined,
     domain,
     { AuthSignature },
     signature
@@ -58,13 +57,6 @@ export const authenticateUser = async (
   if (successCallback) {
     successCallback();
   }
-};
-
-const isSmartWallet = (library) => {
-  return (
-    library.provider.connector &&
-    library.provider.connector?.peerMeta?.name.includes(ARGENT_PEER_NAME)
-  );
 };
 
 const updateAuthToken = (userAddress, token, active = true) => {


### PR DESCRIPTION
This removes the `isSmartWallet()` check on authentication. Verifying the signature via the backend requires this property however `undefined` is always passed as the value. Therefore the unnecessary code has been removed and the api request parameter is hardcoded as undefined (subject to the relevant backend change - i.e. removing the isSmartWallet property altogether).