### PR TITLE
Change to point to AWS backend

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,3 +1,3 @@
-REACT_APP_BACKEND_BASE_URL="https://psyched-hook-280010.oa.r.appspot.com"
+REACT_APP_BACKEND_BASE_URL="https://reference-backend-bsn-development-plutonium.bsn-development-potassium.bosonprotocol.io"
 REACT_APP_FRONT_END_LOCALSTORAGE_VERSION="1.0"
 GENERATE_SOURCEMAP=false


### PR DESCRIPTION
Related to: https://app.asana.com/0/1199560399769920/1199943179890185

This changes the frontend to point to the AWS backend.
The AWS frontend can be accessed at: https://reference-frontend-hassium.bsn-development-potassium.bosonprotocol.io
The "psyched-hook" should no longer be used.