### PR TITLE
Fix ordering of requests - backend and then blockchain

### DIFF
--- a/src/views/new-offer/components/new-offer-submit/NewOfferSubmit.js
+++ b/src/views/new-offer/components/new-offer-submit/NewOfferSubmit.js
@@ -143,23 +143,6 @@ export default function NewOfferSubmit() {
         return;
       }
 
-      const created = await createNewVoucherSet(
-        dataArr,
-        bosonRouterContract,
-        bosonTokenContract,
-        account,
-        chainId,
-        library,
-        price_currency,
-        deposits_currency,
-        modalContext,
-        seller_deposit.add(buyer_deposit)
-      );
-
-      if (!created) {
-        return;
-      }
-
       const paymentType = paymentTypeResolver(
         price_currency,
         deposits_currency
@@ -188,6 +171,23 @@ export default function NewOfferSubmit() {
               "Logging of the smart contract event failed. This does not affect creation of your voucher-set.",
           })
         );
+      }
+
+      const created = await createNewVoucherSet(
+        dataArr,
+        bosonRouterContract,
+        bosonTokenContract,
+        account,
+        chainId,
+        library,
+        price_currency,
+        deposits_currency,
+        modalContext,
+        seller_deposit.add(buyer_deposit)
+      );
+
+      if (!created) {
+        return;
       }
 
       setLoading(0);

--- a/src/views/voucher-and-set-details/VoucherAndSetDetails.js
+++ b/src/views/voucher-and-set-details/VoucherAndSetDetails.js
@@ -312,6 +312,44 @@ function VoucherAndSetDetails(props) {
         return;
       }
 
+      try {
+        const metadata = {
+          _holder: account,
+          _issuer: owner,
+          _tokenIdSupply: supplyId,
+          _correlationId: correlationId,
+        };
+
+        await commitToBuy(voucherSetInfo.id, metadata, authData.authToken);
+      } catch (e) {
+        modalContext.dispatch(
+          ModalResolver.showModal({
+            show: true,
+            type: MODAL_TYPES.GENERIC_ERROR,
+            content: e.message,
+          })
+        );
+        setLoading(0);
+        return;
+      }
+
+      try {
+        const eventData = {
+          name: SMART_CONTRACTS_EVENTS.LOG_VOUCHER_DELIVERED,
+          _correlationId: correlationId,
+        };
+        await createEvent(eventData, authData.authToken);
+      } catch (e) {
+        modalContext.dispatch(
+          ModalResolver.showModal({
+            show: true,
+            type: MODAL_TYPES.GENERIC_ERROR,
+            content:
+              "Logging of the smart contract event failed. This does not affect committing your voucher.",
+          })
+        );
+      }
+
       const tx = await commitToBuyTransactionCreator(
         bosonRouterContract,
         supplyId,
@@ -344,44 +382,6 @@ function VoucherAndSetDetails(props) {
       );
       setLoading(0);
       return;
-    }
-
-    try {
-      const metadata = {
-        _holder: account,
-        _issuer: owner,
-        _tokenIdSupply: supplyId,
-        _correlationId: correlationId,
-      };
-
-      await commitToBuy(voucherSetInfo.id, metadata, authData.authToken);
-    } catch (e) {
-      modalContext.dispatch(
-        ModalResolver.showModal({
-          show: true,
-          type: MODAL_TYPES.GENERIC_ERROR,
-          content: e.message,
-        })
-      );
-      setLoading(0);
-      return;
-    }
-
-    try {
-      const eventData = {
-        name: SMART_CONTRACTS_EVENTS.LOG_VOUCHER_DELIVERED,
-        _correlationId: correlationId,
-      };
-      await createEvent(eventData, authData.authToken);
-    } catch (e) {
-      modalContext.dispatch(
-        ModalResolver.showModal({
-          show: true,
-          type: MODAL_TYPES.GENERIC_ERROR,
-          content:
-            "Logging of the smart contract event failed. This does not affect committing your voucher.",
-        })
-      );
     }
 
     globalContext.dispatch(Action.reduceVoucherSetQuantity(voucherSetInfo.id));


### PR DESCRIPTION
This is related to: https://app.asana.com/0/1199560399769920/1200537305564723

The architectural designs state that, when creating a new voucher set or requesting a voucher, the request should be sent to the backend BEFORE the blockchain action is performed. This is so the record exists in the backend and also as a means of protecting users from losing their funds in the event of a backend error.

This was not the case and has now been fixed for both cases by reordering the request execution.