### PR TITLE
Reverse order of backend-blockchain requests

### DIFF
--- a/src/views/new-offer/components/new-offer-submit/NewOfferSubmit.js
+++ b/src/views/new-offer/components/new-offer-submit/NewOfferSubmit.js
@@ -143,6 +143,23 @@ export default function NewOfferSubmit() {
         return;
       }
 
+      const created = await createNewVoucherSet(
+        dataArr,
+        bosonRouterContract,
+        bosonTokenContract,
+        account,
+        chainId,
+        library,
+        price_currency,
+        deposits_currency,
+        modalContext,
+        seller_deposit.add(buyer_deposit)
+      );
+
+      if (!created) {
+        return;
+      }
+
       const paymentType = paymentTypeResolver(
         price_currency,
         deposits_currency
@@ -171,23 +188,6 @@ export default function NewOfferSubmit() {
               "Logging of the smart contract event failed. This does not affect creation of your voucher-set.",
           })
         );
-      }
-
-      const created = await createNewVoucherSet(
-        dataArr,
-        bosonRouterContract,
-        bosonTokenContract,
-        account,
-        chainId,
-        library,
-        price_currency,
-        deposits_currency,
-        modalContext,
-        seller_deposit.add(buyer_deposit)
-      );
-
-      if (!created) {
-        return;
       }
 
       setLoading(0);

--- a/src/views/voucher-and-set-details/VoucherAndSetDetails.js
+++ b/src/views/voucher-and-set-details/VoucherAndSetDetails.js
@@ -312,6 +312,23 @@ function VoucherAndSetDetails(props) {
         return;
       }
 
+      const tx = await commitToBuyTransactionCreator(
+        bosonRouterContract,
+        supplyId,
+        voucherSetInfo,
+        price,
+        buyerDeposit,
+        bosonTokenContract,
+        library,
+        account,
+        chainId,
+        modalContext
+      );
+      if (!tx) {
+        setLoading(0);
+        return;
+      }
+
       try {
         const metadata = {
           _holder: account,
@@ -348,23 +365,6 @@ function VoucherAndSetDetails(props) {
               "Logging of the smart contract event failed. This does not affect committing your voucher.",
           })
         );
-      }
-
-      const tx = await commitToBuyTransactionCreator(
-        bosonRouterContract,
-        supplyId,
-        voucherSetInfo,
-        price,
-        buyerDeposit,
-        bosonTokenContract,
-        library,
-        account,
-        chainId,
-        modalContext
-      );
-      if (!tx) {
-        setLoading(0);
-        return;
       }
 
       localStorage.setItem("successMessage", "Commit triggered");


### PR DESCRIPTION
This reverses this PR: https://github.com/bosonprotocol/reference-frontend/pull/407

We need to better understand the effects of reordering the requests and why the implementation doesn't match the designs.