### PR TITLE
Make confirmation messages consistent with actions

### DIFF
--- a/src/views/voucher-and-set-details/ControlListProvider.js
+++ b/src/views/voucher-and-set-details/ControlListProvider.js
@@ -34,7 +34,7 @@ export const getControlList = (
         <div
           className="action button cof"
           onClick={() =>
-            confirmAction(onCoF, "Are you sure you want to cancel/fault?")
+            confirmAction(onCoF, "Are you sure you want to cancel or fault?")
           }
           role="button"
         >
@@ -97,7 +97,7 @@ export const getControlList = (
         onClick={() =>
           confirmAction(
             onCancelOrFaultVoucherSet,
-            "Are you sure you want to cancel the voucher set?"
+            "Are you sure you want to void the voucher set?"
           )
         }
         role="button"


### PR DESCRIPTION
Confirmation dialogue for void is inconsistent -> says "cancel" but should say "void".
Confirmation dialogue for CoF is inconsistent -> says "cancel/fault" but should say "cancel or fault".